### PR TITLE
Fix typos and enhance validation

### DIFF
--- a/fennet_mhc/mhc_binding_retriever.py
+++ b/fennet_mhc/mhc_binding_retriever.py
@@ -48,11 +48,11 @@ def get_binding_fdrs(
     decoys_1D: np.ndarray,
     max_fitting_samples=200000,
     random_state=1337,
-    outlier_thredhold=0.01,
+    outlier_threshold=0.01,
     fmm_fdr=False,
 ):
     if fmm_fdr:
-        decoy_fmm = DecoyModel(guassian_outlier_sigma=outlier_thredhold)
+        decoy_fmm = DecoyModel(gaussian_outlier_sigma=outlier_threshold)
         decoy_fmm.fit(decoys_1D)
         if len(distances_1D) >= max_fitting_samples:
             np.random.seed(random_state)
@@ -75,7 +75,7 @@ def get_binding_fdrs(
     else:
         alpha = 1.0 * len(distances_1D) / len(decoys_1D)
         fdrs = get_fdrs(
-            distances_1D, decoys_1D, alpha, remove_rnd_top_rank=outlier_thredhold
+            distances_1D, decoys_1D, alpha, remove_rnd_top_rank=outlier_threshold
         )
 
     fdrs = get_q_values(fdrs, distances_1D)
@@ -101,7 +101,7 @@ def get_binding_fdr_for_best_allele(
             min_allele_distances[selected_alleles],
             rnd_dist[:, i],
             fmm_fdr=fmm_fdr,
-            outlier_thredhold=outlier_threshold,
+            outlier_threshold=outlier_threshold,
         )
         # best_allele_peps[selected_alleles] = peps
         best_allele_fdrs[selected_alleles] = fdrs
@@ -306,7 +306,7 @@ class MHCBindingRetriever:
             best_allele_fdrs[idxes] = get_binding_fdrs(
                 best_allele_dists[idxes],
                 decoy_dists[:, i],
-                outlier_thredhold=self.outlier_threshold,
+                outlier_threshold=self.outlier_threshold,
                 fmm_fdr=self.use_fmm_fdr,
             )
         idxes = (best_allele_dists <= dist_threshold) & (best_allele_fdrs <= fdr)

--- a/fennet_mhc/pipeline_api.py
+++ b/fennet_mhc/pipeline_api.py
@@ -462,9 +462,14 @@ def embed_peptides_from_file(
         peptide_list, peptide_embeds = pretrained_models.embed_peptides_from_fasta(
             peptide_file_path, min_peptide_length, max_peptide_length
         )
-    elif peptide_file_path[-4:].lower() in [".tsv", ".txt", "csv"]:
+    elif peptide_file_path[-4:].lower() in [".tsv", ".txt", ".csv"]:
         peptide_list, peptide_embeds = pretrained_models.embed_peptides_tsv(
             peptide_file_path, min_peptide_length, max_peptide_length
+        )
+    else:
+        raise ValueError(
+            f"Unsupported peptide file format: {peptide_file_path}. "
+            "Please provide a .fasta or .tsv/.csv file."
         )
 
     logging.info(f"Saving peptide_embeddings.pkl to `{out_folder}` ...\n")
@@ -861,13 +866,13 @@ def _load_peptide_embeddings(
         return pretrained_models.embed_peptides_from_fasta(
             peptide_file_path, min_peptide_length, max_peptide_length
         )
-    if peptide_file_path[-4:].lower() in [".tsv", ".txt", "csv"]:
+    if peptide_file_path[-4:].lower() in [".tsv", ".txt", ".csv"]:
         return pretrained_models.embed_peptides_tsv(
             peptide_file_path, min_peptide_length, max_peptide_length
         )
     raise ValueError(
         f"Unsupported peptide file format: {peptide_file_path}. "
-        "Please provide a .pkl or .tsv (.csv) file."
+        "Please provide a .pkl or .tsv/.csv file."
     )
 
 

--- a/fennet_mhc/tda_fmm.py
+++ b/fennet_mhc/tda_fmm.py
@@ -47,7 +47,7 @@ class TDA_fmm:
     def __call__(self, X):
         return self.pdf_mix(X)
 
-    ## Estimate posterior error probilities.
+    ## Estimate posterior error probabilities.
     def pep(self, X, external_pdf=None):
         if self.weights is None or self.external_model is None:
             return np.zeros(len(X))
@@ -122,7 +122,7 @@ class TDA_fmm:
             pp.plot(bins, dis, "r--", linewidth=lw)
             pp.set_title(title + " target")
 
-            # plot false and true distribution seperately
+            # plot false and true distribution separately
             plt.figure()
             pp = plt.subplot()
             dis_false = self.external_model.pdf(bins)
@@ -175,7 +175,7 @@ class TDA_fmm:
             self.n_components + _has_external
         )
 
-        # Response of each components (including the external model),
+        # Response of each component (including the external model),
         # the response: $p_{ik} = w_k*f_k(X_i) / sum(w.*f)$, where k is the kth component.
         post_prob = np.zeros((self.n_components + _has_external, X.shape[0]))
 
@@ -203,7 +203,7 @@ class TDA_fmm:
             ## M-step
             sum_prob = np.sum(post_prob, axis=1)
             sum_prob[sum_prob == 0] = 1e-12
-            # sum all response (R_i) for X_i to estimate the weight of each componets
+            # sum all response (R_i) for X_i to estimate the weight of each component
             new_weights = sum_prob / np.sum(sum_prob)
 
             # New mean is the weighted mean of the responses.
@@ -236,17 +236,17 @@ class TDA_fmm:
 
 
 class DecoyModel(TDA_fmm):
-    def __init__(self, guassian_outlier_sigma, *args, **kwargs):
+    def __init__(self, gaussian_outlier_sigma, *args, **kwargs):
         self.external_model = None
         self.weights = np.array([1.0])
-        self.guassian_outlier_sigma = guassian_outlier_sigma
+        self.gaussian_outlier_sigma = gaussian_outlier_sigma
 
     def fit(self, X):
         self.mu = np.mean(X)
         self.sigma = np.std(X)
 
-        if self.guassian_outlier_sigma:
-            X = X[self.mu - self.guassian_outlier_sigma * self.sigma < X]
+        if self.gaussian_outlier_sigma:
+            X = X[self.mu - self.gaussian_outlier_sigma * self.sigma < X]
             self.mu = np.mean(X)
             self.sigma = np.std(X)
 

--- a/tests/unit_tests/test_metadata.py
+++ b/tests/unit_tests/test_metadata.py
@@ -1,0 +1,6 @@
+from fennet_mhc import __version__, __github__, __license__
+
+def test_package_metadata():
+    assert isinstance(__version__, str) and len(__version__) > 0
+    assert __github__.startswith("https://")
+    assert "Apache" in __license__

--- a/tests/unit_tests/test_pipeline_api.py
+++ b/tests/unit_tests/test_pipeline_api.py
@@ -2,6 +2,7 @@ import os
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from fennet_mhc.constants._const import (
     MHC_DF_FOR_EPITOPES_TSV,
@@ -12,6 +13,7 @@ from fennet_mhc.pipeline_api import (
     PretrainedModels,
     predict_epitopes_for_mhc,
     predict_mhc_binders_for_epitopes,
+    _load_peptide_embeddings,
 )
 
 TEST_PEPTIDE_TSV = os.path.abspath("./test_data/test_peptides.tsv")
@@ -119,3 +121,18 @@ def test_predict_binders_for_epitopes():
 #     )
 #     assert os.path.exists(f"{OUT_DIR}/{PEPTIDE_DECONVOLUTION_CLUSTER_DF_TSV}")
 #     assert os.path.getsize(f"{OUT_DIR}/{PEPTIDE_DECONVOLUTION_CLUSTER_DF_TSV}") > 0
+
+
+class DummyModels:
+    def embed_peptides_from_fasta(self, *args, **kwargs):
+        return [], np.empty((0, 1))
+
+    def embed_peptides_tsv(self, *args, **kwargs):
+        return [], np.empty((0, 1))
+
+
+def test_load_peptide_embeddings_invalid_extension(tmp_path):
+    bad_file = tmp_path / "peptides.bad"
+    bad_file.write_text("AA")
+    with pytest.raises(ValueError):
+        _load_peptide_embeddings(DummyModels(), str(bad_file), 8, 12)


### PR DESCRIPTION
## Summary
- fix `outlier_threshold` parameter name in `mhc_binding_retriever.py`
- properly check `.csv` extensions in `pipeline_api`
- clarify a comment in `tda_fmm`
- add unit test for invalid peptide file extension

## Testing
- `pytest -k 'not slow'` *(fails: command not found)*