### PR TITLE
Add docstrings and type hints to mhc_utils

### DIFF
--- a/fennet_mhc/mhc_utils.py
+++ b/fennet_mhc/mhc_utils.py
@@ -1,4 +1,9 @@
+"""Utility helpers for handling peptide and protein sequences."""
+
+from __future__ import annotations
+
 import os
+from collections.abc import Sequence
 
 import numpy as np
 import pandas as pd
@@ -6,8 +11,25 @@ from alphabase.protein.fasta import load_all_proteins
 from alphabase.protein.lcp_digest import get_substring_indices
 
 
-def load_peptide_df_from_mixmhcpred(mixmhcpred_dir, rank=2):
-    df_list = []
+def load_peptide_df_from_mixmhcpred(mixmhcpred_dir: str, rank: int = 2) -> pd.DataFrame:
+    """Load peptides predicted by MixMHCpred.
+
+    This function reads all result files from a directory produced by
+    MixMHCpred and collects peptide sequences with a rank below a specified
+    threshold.
+
+    Args:
+        mixmhcpred_dir (str): Path to the directory containing MixMHCpred
+            output ``.tsv`` files.
+        rank (int): Maximum ``%Rank_bestAllele`` value to keep. Only peptides
+            with a rank less than or equal to this value are returned.
+
+    Returns:
+        pandas.DataFrame: A DataFrame with columns ``sequence`` and ``allele``
+            containing the filtered peptides.
+    """
+
+    df_list: list[pd.DataFrame] = []
     for fname in os.listdir(mixmhcpred_dir):
         df = pd.read_table(os.path.join(mixmhcpred_dir, fname), skiprows=11)
         df = df.query(f"`%Rank_bestAllele`<={rank}").copy()
@@ -19,12 +41,26 @@ def load_peptide_df_from_mixmhcpred(mixmhcpred_dir, rank=2):
 
 
 class NonSpecificDigest:
+    """Generate peptides from a protein sequence without specific cleavage."""
+
     def __init__(
         self,
-        protein_data: tuple[pd.DataFrame, list, str],
-        min_peptide_len=8,
-        max_peptide_len=14,
-    ):
+        protein_data: pd.DataFrame | list[str] | str,
+        min_peptide_len: int = 8,
+        max_peptide_len: int = 14,
+    ) -> None:
+        """Create a digestion helper.
+
+        Args:
+            protein_data (Union[pandas.DataFrame, list[str], str]): Either a
+                DataFrame with a ``sequence`` column, a path to a fasta file, or
+                a list of fasta file paths containing protein sequences.
+            min_peptide_len (int): Minimum peptide length produced by the
+                digestion.
+            max_peptide_len (int): Maximum peptide length produced by the
+                digestion.
+        """
+
         if isinstance(protein_data, pd.DataFrame):
             self.cat_protein_sequence = (
                 "$" + "$".join(protein_data.sequence.values) + "$"
@@ -40,7 +76,17 @@ class NonSpecificDigest:
             self.cat_protein_sequence, min_peptide_len, max_peptide_len
         )
 
-    def get_random_pept_df(self, n=5000):
+    def get_random_pept_df(self, n: int = 5000) -> pd.DataFrame:
+        """Randomly sample digested peptides.
+
+        Args:
+            n (int): Number of peptides to sample.
+
+        Returns:
+            pandas.DataFrame: DataFrame with a ``sequence`` column containing the
+            sampled peptides and an ``allele`` column set to ``"random"``.
+        """
+
         idxes = np.random.randint(0, len(self.digest_starts), size=n)
         df = pd.DataFrame(
             [
@@ -54,7 +100,19 @@ class NonSpecificDigest:
         df["allele"] = "random"
         return df
 
-    def get_peptide_seqs_from_idxes(self, idxes):
+    def get_peptide_seqs_from_idxes(
+        self, idxes: Sequence[int] | np.ndarray
+    ) -> list[str]:
+        """Return peptide sequences for the given digest indices.
+
+        Args:
+            idxes (Sequence[int] | numpy.ndarray): Indices into the digested
+                peptide list.
+
+        Returns:
+            list[str]: The peptide sequences corresponding to ``idxes``.
+        """
+
         return [
             self.cat_protein_sequence[start:stop]
             for start, stop in zip(


### PR DESCRIPTION
## Summary
- document `load_peptide_df_from_mixmhcpred`
- document `NonSpecificDigest` and its methods
- annotate functions with type hints

## Testing
- `ruff format fennet_mhc/mhc_utils.py`
- `ruff check fennet_mhc/mhc_utils.py`
- `bash tests/run_unit_tests.sh` *(fails: `conda: command not found`)*