### PR TITLE
Improve packaging metadata, add auto device selection, and polish CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Foundation model for MHC class I peptide binding prediction built on deep contrastive learning.
 
-See the [online documentation](https://fennet.mhc.readthedocs.io/en/latest) for
+See the [online documentation](https://fennet-mhc.readthedocs.io/en/latest) for
 full API details and tutorials.
 
 ## Installation

--- a/fennet_mhc/__init__.py
+++ b/fennet_mhc/__init__.py
@@ -1,4 +1,4 @@
 __version__ = "0.0.1-dev0"
-__github__ = "https://github.com/FennOmix/Fennet.MHC"
+__github__ = "https://github.com/FennOmix/FeNNet.MHC"
 __doc__ = "https://fennet-mhc.readthedocs.io/en/latest/"
 __license__ = "Apache 2.0"

--- a/fennet_mhc/cli.py
+++ b/fennet_mhc/cli.py
@@ -57,10 +57,13 @@ def check():
 )
 @click.option(
     "--device",
-    type=click.Choice(["cpu", "cuda", "mps"]),
-    default="cuda",
+    type=click.Choice(["auto", "cpu", "cuda", "mps"]),
+    default="auto",
     show_default=True,
-    help="Device to use. Options: 'cpu', 'cuda' (for NVIDIA GPUs), or 'mps' (for Apple Silicon GPUs).",
+    help=(
+        "Device to use. 'auto' picks best available (cuda > mps > cpu). "
+        "Options: 'auto', 'cpu', 'cuda' (NVIDIA GPUs), 'mps' (Apple Silicon)."
+    ),
 )
 def embed_proteins(fasta, out_folder, device):
     import fennet_mhc.pipeline_api as pipeline_api
@@ -100,10 +103,13 @@ def embed_proteins(fasta, out_folder, device):
 )
 @click.option(
     "--device",
-    type=click.Choice(["cpu", "cuda", "mps"]),
-    default="cuda",
+    type=click.Choice(["auto", "cpu", "cuda", "mps"]),
+    default="auto",
     show_default=True,
-    help="Device to use. Options: 'cpu', 'cuda' (for NVIDIA GPUs), or 'mps' (for Apple Silicon GPUs).",
+    help=(
+        "Device to use. 'auto' picks best available (cuda > mps > cpu). "
+        "Options: 'auto', 'cpu', 'cuda' (NVIDIA GPUs), 'mps' (Apple Silicon)."
+    ),
 )
 def embed_peptides(
     peptide_file,
@@ -173,16 +179,20 @@ def embed_peptides(
     "--hla-file",
     default=None,
     required=False,
-    help="Path to the fasta file or pre-computed MHC protein embeddings file (.pkl) or fasta file. "
-    "If None, a default embeddings file cotaining 15672 alleles is provided. "
-    "If your desired alleles are not included in the default file, ",
+    help=(
+        "Path to a FASTA file of HLA sequences or a precomputed embeddings "
+        "pickle (.pkl). If None, a default library with 15,672 alleles is used."
+    ),
 )
 @click.option(
     "--device",
-    type=click.Choice(["cpu", "cuda", "mps"]),
-    default="cuda",
+    type=click.Choice(["auto", "cpu", "cuda", "mps"]),
+    default="auto",
     show_default=True,
-    help="Device to use. Options: 'cpu', 'cuda' (for NVIDIA GPUs), or 'mps' (for Apple Silicon GPUs).",
+    help=(
+        "Device to use. 'auto' picks best available (cuda > mps > cpu). "
+        "Options: 'auto', 'cpu', 'cuda' (NVIDIA GPUs), 'mps' (Apple Silicon)."
+    ),
 )
 def predict_epitopes_for_mhc(
     peptide_file,
@@ -250,17 +260,20 @@ def predict_epitopes_for_mhc(
 @click.option(
     "--hla-file",
     default=None,
-    help="Path to the pre-computed MHC protein embeddings file (.pkl). "
-    "If None, a default embeddings file will be used. "
-    "If your desired alleles are not included in the default file, "
-    "you can generate a custom embeddings file using the *embed_proteins* command.",
+    help=(
+        "Path to a precomputed HLA embeddings pickle (.pkl). If None, the "
+        "default library is used. To build a custom library, run embed-proteins."
+    ),
 )
 @click.option(
     "--device",
-    type=click.Choice(["cpu", "cuda", "mps"]),
-    default="cuda",
+    type=click.Choice(["auto", "cpu", "cuda", "mps"]),
+    default="auto",
     show_default=True,
-    help="Device to use. Options: 'cpu', 'cuda' (for NVIDIA GPUs), or 'mps' (for Apple Silicon GPUs).",
+    help=(
+        "Device to use. 'auto' picks best available (cuda > mps > cpu). "
+        "Options: 'auto', 'cpu', 'cuda' (NVIDIA GPUs), 'mps' (Apple Silicon)."
+    ),
 )
 def predict_mhc_binders_for_epitopes(
     peptide_file,
@@ -324,16 +337,20 @@ def predict_mhc_binders_for_epitopes(
     "--hla-file",
     default=None,
     required=False,
-    help="Path to the fasta file or pre-computed MHC protein embeddings file (.pkl) or fasta file. "
-    "If None, a default embeddings file cotaining 15672 alleles is provided. "
-    "If your desired alleles are not included in the default file, ",
+    help=(
+        "Path to a FASTA file of HLA sequences or a precomputed embeddings "
+        "pickle (.pkl). If None, a default library with 15,672 alleles is used."
+    ),
 )
 @click.option(
     "--device",
-    type=click.Choice(["cpu", "cuda", "mps"]),
-    default="cuda",
+    type=click.Choice(["auto", "cpu", "cuda", "mps"]),
+    default="auto",
     show_default=True,
-    help="Device to use. Options: 'cpu', 'cuda' (for NVIDIA GPUs), or 'mps' (for Apple Silicon GPUs).",
+    help=(
+        "Device to use. 'auto' picks best available (cuda > mps > cpu). "
+        "Options: 'auto', 'cpu', 'cuda' (NVIDIA GPUs), 'mps' (Apple Silicon)."
+    ),
 )
 def deconvolute_peptides(
     peptide_file,
@@ -413,16 +430,20 @@ def deconvolute_peptides(
     "--hla-file",
     default=None,
     required=False,
-    help="Path to the fasta file or pre-computed MHC protein embeddings file (.pkl) or fasta file. "
-    "If None, a default embeddings file cotaining 15672 alleles is provided. "
-    "If your desired alleles are not included in the default file, ",
+    help=(
+        "Path to a FASTA file of HLA sequences or a precomputed embeddings "
+        "pickle (.pkl). If None, a default library with 15,672 alleles is used."
+    ),
 )
 @click.option(
     "--device",
-    type=click.Choice(["cpu", "cuda", "mps"]),
-    default="cuda",
+    type=click.Choice(["auto", "cpu", "cuda", "mps"]),
+    default="auto",
     show_default=True,
-    help="Device to use. Options: 'cpu', 'cuda' (for NVIDIA GPUs), or 'mps' (for Apple Silicon GPUs).",
+    help=(
+        "Device to use. 'auto' picks best available (cuda > mps > cpu). "
+        "Options: 'auto', 'cpu', 'cuda' (NVIDIA GPUs), 'mps' (Apple Silicon)."
+    ),
 )
 def deconvolute_and_predict_peptides(
     peptide_file_to_deconv,
@@ -453,4 +474,5 @@ def deconvolute_and_predict_peptides(
 
 
 if __name__ == "__main__":
+    run()
     run()

--- a/fennet_mhc/pipeline_api.py
+++ b/fennet_mhc/pipeline_api.py
@@ -1065,16 +1065,23 @@ def _set_device(device: str) -> str:
     Select the appropriate device based on availability.
 
     Args:
-        device (str): The desired device ('cpu', 'cuda', or 'mps').
+        device (str): The desired device ('auto', 'cpu', 'cuda', or 'mps').
 
     Returns:
         str: The selected device ('cpu', 'cuda', or 'mps').
     """
-    if device.startswith("cuda") and not torch.cuda.is_available():
-        print("CUDA not available. Change to use CPU.")
+    if device == "auto":
+        if torch.cuda.is_available():
+            device = "cuda"
+        elif torch.backends.mps.is_available():
+            device = "mps"
+        else:
+            device = "cpu"
+    elif device.startswith("cuda") and not torch.cuda.is_available():
+        print("CUDA not available. Falling back to CPU.")
         device = "cpu"
     elif device == "mps" and not torch.backends.mps.is_available():
-        print("MPS (Apple Silicon GPU) not available. Change to use CPU.")
+        print("MPS (Apple Silicon GPU) not available. Falling back to CPU.")
         device = "cpu"
 
     print(f"Using device: {device}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ maintainers = [
 ]
 description = "Fennet-MHC"
 readme = "README.md"
-license = {file = "LICENSE.txt"}
+license = {file = "LICENSE"}
 keywords = [
   "contrastive learning", "protein language model",
   "immunopeptidomics", "mass spectrometry",
@@ -25,7 +25,14 @@ keywords = [
 ]
 classifiers = [
   "Development Status :: 1 - Planning",
-  "Programming Language :: Python"
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: Apache Software License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
 ]
 # __classifiers__ = [
 #     "Development Status :: 1 - Planning",
@@ -44,10 +51,9 @@ classifiers = [
 
 [project.urls]
 Homepage = "https://fennomix.lab.westlake.edu.cn"
-Documentation = "https://readthedocs.org"
-Repository = "https://github.com/FennOmix/fennet.mhc.git"
-"Bug Tracker" = "https://github.com/FennOmix/fennet.mhc/issues"
-Changelog = "https://github.com/FennOmix/fennet.mhc/blob/main/CHANGELOG.md"
+Documentation = "https://fennet-mhc.readthedocs.io/en/latest"
+Repository = "https://github.com/FennOmix/FeNNet.MHC"
+"Bug Tracker" = "https://github.com/FennOmix/FeNNet.MHC/issues"
 
 [project.scripts]
 fennet-mhc = "fennet_mhc.cli:run"


### PR DESCRIPTION
Summary
- Add an “auto” device option and make it the default (cuda > mps > cpu).
- Fix packaging metadata (license file, URLs, classifiers) to improve PyPI presentation and links.
- Clean up CLI help text for --hla-file, fix typos, and ensure module invocation works.

Changes
- pyproject.toml: license file to LICENSE; correct docs/repo/issue URLs; add standard classifiers (license, audience, Python 3.10–3.11).
- fennet_mhc/cli.py: add --device auto (default for all commands); clarify --hla-file help; add run() under __main__.
- fennet_mhc/pipeline_api.py: _set_device supports ‘auto’ and clear fallbacks.
- README.md: fix ReadTheDocs link to https://fennet-mhc.readthedocs.io/en/latest.
- fennet_mhc/__init__.py: unify __github__ to canonical repo URL.

Notes
- Python support remains >=3.10,<3.12.
- Consider adding CI to lint (ruff) and build packages to catch metadata regressions.
