### PR TITLE
chore/docs: add community docs and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behavior:
+1. Command or code used
+2. Input files/parameters
+3. Error output or incorrect result
+
+## Expected behavior
+What you expected to happen.
+
+## Environment
+- OS: (e.g., Ubuntu 22.04, macOS 14)
+- Python: (e.g., 3.11)
+- fennet-mhc version: (`pip show fennet-mhc` or commit SHA)
+
+## Additional context
+Add any other context, logs, or screenshots here.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+## Summary
+Describe the feature or improvement you’d like to see.
+
+## Motivation
+What problem does this solve? Who benefits?
+
+## Proposed solution
+Outline your approach, API changes, and any alternatives considered.
+
+## Additional context
+Links, references, mockups, or related issues.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+Title
+- chore/docs: add community docs and templates
+
+Summary
+- Briefly describe the change and why it’s needed.
+
+Changes
+- [ ] Add CONTRIBUTING.md
+- [ ] Add CODE_OF_CONDUCT.md
+- [ ] Add SECURITY.md
+- [ ] Add issue templates (bug, feature)
+- [ ] Add PR template
+
+Testing
+- Describe what you tested locally and any CI checks.
+
+Checklist
+- [ ] Pre-commit hooks pass (ruff/format/lint)
+- [ ] Tests pass locally (pytest)
+- [ ] Docs updated (if behavior changed)
+- [ ] Linked issues (if any)
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+Contributor Covenant Code of Conduct
+
+Our Pledge
+We as members, contributors, and leaders pledge to make participation in our project and our community a harassment‑free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio‑economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+Our Standards
+Examples of behavior that contributes to a positive environment for our community include:
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior include:
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+Enforcement Responsibilities
+Community leaders are responsible for clarifying and enforcing our standards and will take appropriate and fair corrective action in response to any behavior they deem inappropriate, threatening, offensive, or harmful.
+
+Scope
+This Code of Conduct applies within all community spaces and also applies when an individual is officially representing the community in public spaces.
+
+Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers at zengwenfeng@westlake.edu.cn and 1274873858@qq.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+Enforcement Guidelines
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+- Correction
+- Warning
+- Temporary Ban
+- Permanent Ban
+
+Attribution
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1, available at https://www.contributor-covenant.org/version/2/1/code_of_conduct.html. Community Impact Guidelines were inspired by Mozilla’s code of conduct enforcement ladder.
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+Contributing to FeNNet.MHC
+
+Thanks for your interest in contributing! This guide helps you set up a dev environment, run checks, and submit high‑quality pull requests.
+
+Getting started
+- Python: 3.10–3.11 (matches CI matrix)
+- OS: Linux, macOS, or Windows
+- Package manager: pip or conda
+
+Local setup (pip/venv)
+1) Clone and create a virtual environment
+   - python -m venv .venv && source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+2) Install in editable mode with dev extras
+   - pip install -U pip
+   - pip install -e ".[development]"
+
+Local setup (conda)
+1) Create env and install
+   - conda create -n fennet-mhc python=3.11 -y
+   - conda activate fennet-mhc
+   - pip install -e ".[development]"
+
+Pre-commit hooks
+- Install once: pre-commit install
+- Run on all files: pre-commit run -a
+
+Running tests
+- Quick run with pytest (skips slow tests):
+  - pytest -k "not slow"
+- With coverage:
+  - coverage run --source=fennet_mhc -m pytest -k "not slow" && coverage report
+- The CI also provides helper scripts under tests/ and misc/ for conda-based runs.
+
+Docs
+- Build docs locally (optional):
+  - pip install -e ".[docs]"
+  - sphinx-build -b html docs ./site
+
+Commit style and branching
+- Create a feature branch from main, e.g. chore/add-community-docs
+- Keep commits focused; run hooks and tests before pushing
+- Reference issues in commit messages and PR descriptions when relevant
+
+Pull requests
+- Ensure: hooks pass, tests pass, and new/changed code is covered
+- Add or update documentation when behavior changes
+- Fill out the PR template with context, testing notes, and screenshots/output
+
+Reporting issues
+- Use the GitHub issue templates (Bug report / Feature request)
+- Include repro steps, expected vs. actual behavior, environment info, and logs
+
+Code of Conduct
+- By participating you agree to abide by our Code of Conduct (see CODE_OF_CONDUCT.md). Report concerns as described therein.
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+Security Policy
+
+Supported versions
+- Latest main branch and the most recent released version on PyPI receive security fixes when feasible.
+
+Reporting a vulnerability
+- Please report security issues privately via:
+  - GitHub Security Advisory: https://github.com/FennOmix/FeNNet.MHC/security/advisories
+  - Or email the maintainers: zengwenfeng@westlake.edu.cn, 1274873858@qq.com
+- Provide a detailed description, reproduction steps, impacted versions, and any proof‑of‑concept if available.
+- We will acknowledge receipt within 5 business days and keep you informed of the remediation timeline.
+
+Public disclosure
+- Please do not create public issues for security vulnerabilities until a fix is available and coordinated disclosure is agreed.
+


### PR DESCRIPTION
This PR adds community and contributor documentation to improve project onboarding and collaboration.\n\nChanges\n- Add CONTRIBUTING.md with local setup, testing, and PR guidance\n- Add CODE_OF_CONDUCT.md (Contributor Covenant 2.1)\n- Add SECURITY.md with reporting instructions\n- Add GitHub issue templates (bug report, feature request)\n- Add a pull request template\n\nNotes\n- No code changes; documentation only.\n- Happy to tweak language, sections, or structure based on maintainer preferences.